### PR TITLE
Fixed bug with bundles

### DIFF
--- a/MBFaker/MBFakerHelper.m
+++ b/MBFaker/MBFakerHelper.m
@@ -15,7 +15,7 @@
 + (NSDictionary*)translations {
     NSMutableDictionary* translationsDictionary = [[NSMutableDictionary alloc] init];
     
-    NSArray* translationPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"yml" inDirectory:@""];
+    NSArray* translationPaths = [[NSBundle NSBundle bundleForClass:[MBFakerHelper class]] pathsForResourcesOfType:@"yml" inDirectory:@""];
     
     for (NSString* path in translationPaths) {
         NSInputStream *stream = [[NSInputStream alloc] initWithFileAtPath: path];


### PR DESCRIPTION
Without this fix my project's unit tests crashed when I tried to call NSString *newName = [MBFakerName name].
