### PR TITLE
Enable loading files from bundle specified by class

### DIFF
--- a/MBFaker/MBFakerHelper.m
+++ b/MBFaker/MBFakerHelper.m
@@ -15,7 +15,7 @@
 + (NSDictionary*)translations {
     NSMutableDictionary* translationsDictionary = [[NSMutableDictionary alloc] init];
     
-    NSArray* translationPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"yml" inDirectory:@""];
+    NSArray* translationPaths = [[NSBundle bundleForClass:[self class]] pathsForResourcesOfType:@"yml" inDirectory:@""];
     
     for (NSString* path in translationPaths) {
         NSInputStream *stream = [[NSInputStream alloc] initWithFileAtPath: path];


### PR DESCRIPTION
This enabled MBFaker to be used out of the box in unit tests
