### PR TITLE
Add support for OS X apps

### DIFF
--- a/MBFaker.podspec
+++ b/MBFaker.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
 	      s.name     = 'MBFaker'
 	      s.version  = '0.1.2'
 	      s.platform = :ios, '5.0'
+	      s.platform = :osx, '10.7'
 	      s.license  = 'MIT'
 	      s.summary  = 'Library that generates fake data.'
 	      s.homepage = 'https://github.com/bananita/MBFaker'


### PR DESCRIPTION
This library seems to work for OS X targets without any code modifications, but the Podspec is currently set to iOS only.  This pull request adds OS X support on the Podspec.
