### PR TITLE
Fix issue #8

### DIFF
--- a/MBFaker/MBFakerHelper.m
+++ b/MBFaker/MBFakerHelper.m
@@ -15,7 +15,7 @@
 + (NSDictionary*)translations {
     NSMutableDictionary* translationsDictionary = [[NSMutableDictionary alloc] init];
     
-    NSArray* translationPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"yml" inDirectory:@""];
+    NSArray* translationPaths = [[NSBundle bundleForClass:[self class]] pathsForResourcesOfType:@"yml" inDirectory:@""];
     
     for (NSString* path in translationPaths) {
         NSInputStream *stream = [[NSInputStream alloc] initWithFileAtPath: path];


### PR DESCRIPTION
It turns out that if you're running MBFaker inside a test bundle (like me), **[NSBundle mainBundle]** will return the app bundle. That being said, _pathsForResourcesOfType:inDirectory_ was returning an empty array.

By changing it to **[[NSBundle bundleForClass:[self class]]**, the translation files will be returned, regardless of which bundle it is.
