### PR TITLE
Enables MBFaker to be used as a Pod framework.

### DIFF
--- a/MBFaker/MBFakerHelper.m
+++ b/MBFaker/MBFakerHelper.m
@@ -15,7 +15,7 @@
 + (NSDictionary*)translations {
     NSMutableDictionary* translationsDictionary = [[NSMutableDictionary alloc] init];
     
-    NSArray* translationPaths = [[NSBundle bundleForClass:[self class]] pathsForResourcesOfType:@"yml" inDirectory:@""];
+    NSArray* translationPaths = [[NSBundle bundleForClass:self] pathsForResourcesOfType:@"yml" inDirectory:@"" ];
     
     for (NSString* path in translationPaths) {
         NSInputStream *stream = [[NSInputStream alloc] initWithFileAtPath: path];


### PR DESCRIPTION
Otherwise, the translation YML files can never be found.
